### PR TITLE
Fixed form text note IME issue

### DIFF
--- a/lib/com/hydrologis/flutterlibs/forms/forms_widgets.dart
+++ b/lib/com/hydrologis/flutterlibs/forms/forms_widgets.dart
@@ -331,12 +331,6 @@ ListTile getWidget(
     TYPE_STRING:
     case TYPE_STRING:
       {
-        TextEditingController stringController =
-            new TextEditingController(text: value);
-
-        stringController.addListener(() {
-          itemMap[TAG_VALUE] = stringController.text;
-        });
         TextFormField field = TextFormField(
           validator: (value) {
             if (!constraints.isValid(value)) {
@@ -349,7 +343,10 @@ ListTile getWidget(
 //            icon: icon,
             labelText: "$label ${constraints.getDescription()}",
           ),
-          controller: stringController,
+          initialValue: value,
+          onChanged: (text) {
+            itemMap[TAG_VALUE] = text;
+          },
           enabled: !itemReadonly,
           minLines: minLines,
           maxLines: maxLines,


### PR DESCRIPTION
This is my trial to fix the following issue.
- [Form text note Japanese input (with IME) doesn't work correctly on Android · Issue #111 · moovida/smash](https://github.com/moovida/smash/issues/111)

The direct cause seems to be the widget is recreated during text change, so it is similar with the following Japanese article,
https://qiita.com/kurararara/items/b59ff3f8d6a2ce416220

and I couldn't find other good way except this PR's changing `TextEditingController.addListener` => `TextFormField.onChanged` way...